### PR TITLE
Carousel: reposition itself on change of orientation

### DIFF
--- a/carousel/src/carousel.js
+++ b/carousel/src/carousel.js
@@ -259,7 +259,8 @@ Mobify.UI.Carousel = (function($, Utils) {
             , $inner = this.$inner
             , opts = this.options
             , lockLeft = false
-            , lockRight = false;
+            , lockRight = false
+            , windowWidth = $(window).width();
 
         function start(e) {
             if (!has.touch) e.preventDefault();
@@ -362,8 +363,12 @@ Mobify.UI.Carousel = (function($, Utils) {
             // Disable animation for now to avoid seeing 
             // the carousel sliding, as it updates its position.
             // Animation will be enabled automatically when you're swiping.
+            // Don't update Carousel on window height change
+            if(windowWidth == $(window).width())
+                return;
+
             self._disableAnimation();
-            
+            windowWidth = $(window).width();
             self.update();
         });
 

--- a/carousel/src/carousel.js
+++ b/carousel/src/carousel.js
@@ -413,6 +413,9 @@ Mobify.UI.Carousel = (function($, Utils) {
             //return; // Return Type?
         }
 
+        // Making sure that animation is enabled before moving
+        this._enableAnimation();
+
         // Trigger beforeSlide event
         $element.trigger('beforeSlide', [index, newIndex]);
 


### PR DESCRIPTION
It used to be that switching from portrait to landscape (and vice
versa) would leave the carousel in between two images or on the
wrong image.

(Thanks to @donnielrt and @Helen-Mobify. I'm just integrating their work.)
