### PR TITLE
Carousel: not using transform3d for android devices

### DIFF
--- a/carousel/src/carousel.js
+++ b/carousel/src/carousel.js
@@ -18,7 +18,8 @@ Mobify.UI = Mobify.UI ? Mobify.$.extend(Mobify.UI, { classPrefix: 'm-' }) : { cl
 */
 Mobify.UI.Utils = (function($) {
     var exports = {}
-        , has = $.support;
+        , has = $.support
+        , ua = navigator.userAgent;
 
     /**
         Events (either touch or mouse)
@@ -59,7 +60,7 @@ Mobify.UI.Utils = (function($) {
 
     $.extend(has, {
         'transform': !! (exports.getProperty('Transform'))
-      , 'transform3d': !! (window.WebKitCSSMatrix && 'm11' in new WebKitCSSMatrix()) 
+      , 'transform3d': !! (window.WebKitCSSMatrix && 'm11' in new WebKitCSSMatrix() && !/android/i.test(ua)) 
     });
 
     // translateX(element, delta)

--- a/carousel/src/carousel.js
+++ b/carousel/src/carousel.js
@@ -60,6 +60,10 @@ Mobify.UI.Utils = (function($) {
 
     $.extend(has, {
         'transform': !! (exports.getProperty('Transform'))
+
+        // Usage of transform3d on *android* would cause problems for input fields:
+        // - https://coderwall.com/p/d5lmba
+        // - http://static.trygve-lie.com/bugs/android_input/
       , 'transform3d': !! (window.WebKitCSSMatrix && 'm11' in new WebKitCSSMatrix() && !/android/i.test(ua)) 
     });
 

--- a/carousel/src/carousel.js
+++ b/carousel/src/carousel.js
@@ -64,7 +64,7 @@ Mobify.UI.Utils = (function($) {
         // Usage of transform3d on *android* would cause problems for input fields:
         // - https://coderwall.com/p/d5lmba
         // - http://static.trygve-lie.com/bugs/android_input/
-      , 'transform3d': !! (window.WebKitCSSMatrix && 'm11' in new WebKitCSSMatrix() && !/android/i.test(ua)) 
+      , 'transform3d': !! (window.WebKitCSSMatrix && 'm11' in new WebKitCSSMatrix() && !/android\s+[1-2]/i.test(ua)) 
     });
 
     // translateX(element, delta)


### PR DESCRIPTION
Usage of transform3d on android would cause problems for input fields:
- https://coderwall.com/p/d5lmba
- http://static.trygve-lie.com/bugs/android_input/

(Credit goes to @donnielrt)
