### PR TITLE
Fixed panel height issue during the closing animation

### DIFF
--- a/pikabu/bld/pikabu.css
+++ b/pikabu/bld/pikabu.css
@@ -1,1 +1,121 @@
-*{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.m-pikabu-viewport{position:relative;display:-webkit-box;display:-moz-box;display:-ms-box;display:box;-webkit-box-orient:horizontal;-moz-box-orient:horizontal;-ms-box-orient:horizontal;box-orient:horizontal;overflow:hidden;-webkit-perspective:1000;-webkit-transform:translateZ(0);-webkit-backface-visibility:hidden}.m-pikabu-sidebar{position:absolute;overflow:visible;display:block;width:80%;background:#222}.m-pikabu-sidebar.m-pikabu-left{-webkit-transform:translate3d(-100%, 0, 0);-moz-transform:translate3d(-100%, 0, 0);-ms-transform:translate3d(-100%, 0, 0);-o-transform:translate3d(-100%, 0, 0);transform:translate3d(-100%, 0, 0)}.m-pikabu-sidebar.m-pikabu-right{right:0;-webkit-transform:translate3d(100%, 0, 0);-moz-transform:translate3d(100%, 0, 0);-ms-transform:translate3d(100%, 0, 0);-o-transform:translate3d(100%, 0, 0);transform:translate3d(100%, 0, 0)}.m-pikabu-left-visible .m-pikabu-sidebar.m-pikabu-left,.m-pikabu-right-visible .m-pikabu-sidebar.m-pikabu-right{-webkit-transform:translate3d(0, 0, 0);-moz-transform:translate3d(0, 0, 0);-ms-transform:translate3d(0, 0, 0);-o-transform:translate3d(0, 0, 0);transform:translate3d(0, 0, 0)}.m-pikabu-container{width:100%;-webkit-backface-visibility:hidden}.m-pikabu-left-visible .m-pikabu-container.m-pikabu-left,.m-pikabu-right-visible .m-pikabu-container.m-pikabu-right{position:absolute}.m-pikabu-left-visible .m-pikabu-container{-webkit-transform:translate3d(80%, 0, 0);-moz-transform:translate3d(80%, 0, 0);-ms-transform:translate3d(80%, 0, 0);-o-transform:translate3d(80%, 0, 0);transform:translate3d(80%, 0, 0)}.m-pikabu-right-visible .m-pikabu-container{-webkit-transform:translate3d(-80%, 0, 0);-moz-transform:translate3d(-80%, 0, 0);-ms-transform:translate3d(-80%, 0, 0);-o-transform:translate3d(-80%, 0, 0);transform:translate3d(-80%, 0, 0)}.m-pikabu-container,.m-pikabu-sidebar{-webkit-transition:-webkit-transform 0.2s ease-in;-moz-transition:-webkit-transform 0.2s ease-in;-o-transition:-webkit-transform 0.2s ease-in;transition:-webkit-transform 0.2s ease-in}.m-pikabu-overlay{display:none}.m-pikabu-left-visible .m-pikabu-overlay,.m-pikabu-right-visible .m-pikabu-overlay{position:absolute;top:0;z-index:30;display:block;height:100%;width:100%;cursor:pointer}img{max-width:100%}.m-pikabu-overflow-scrolling .m-pikabu-sidebar{overflow:auto}.m-pikabu-overflow-touch{-webkit-overflow-scrolling:touch}
+@charset "UTF-8";
+/* line 4, ../src/sass/pikabu.scss */
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/* line 8, ../src/sass/pikabu.scss */
+.m-pikabu-viewport {
+  position: relative;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-box;
+  display: box;
+  -webkit-box-orient: horizontal;
+  -moz-box-orient: horizontal;
+  -ms-box-orient: horizontal;
+  box-orient: horizontal;
+  overflow: hidden;
+  min-height: 100%;
+  -webkit-perspective: 1000;
+  -webkit-transform: translateZ(0);
+  -webkit-backface-visibility: hidden;
+}
+
+/* line 21, ../src/sass/pikabu.scss */
+.m-pikabu-sidebar {
+  position: absolute;
+  overflow: visible;
+  display: block;
+  width: 80%;
+  background: #222;
+  color: white;
+  padding: 20px;
+}
+/* line 33, ../src/sass/pikabu.scss */
+.m-pikabu-sidebar.m-pikabu-left {
+  -webkit-transform: translate3d(-100%, 0, 0);
+  -moz-transform: translate3d(-100%, 0, 0);
+  -ms-transform: translate3d(-100%, 0, 0);
+  -o-transform: translate3d(-100%, 0, 0);
+  transform: translate3d(-100%, 0, 0);
+}
+/* line 37, ../src/sass/pikabu.scss */
+.m-pikabu-sidebar.m-pikabu-right {
+  right: 0;
+  -webkit-transform: translate3d(100%, 0, 0);
+  -moz-transform: translate3d(100%, 0, 0);
+  -ms-transform: translate3d(100%, 0, 0);
+  -o-transform: translate3d(100%, 0, 0);
+  transform: translate3d(100%, 0, 0);
+}
+/* line 43, ../src/sass/pikabu.scss */
+.m-pikabu-left-visible .m-pikabu-sidebar.m-pikabu-left, .m-pikabu-right-visible .m-pikabu-sidebar.m-pikabu-right {
+  -webkit-transform: translate3d(0, 0, 0);
+  -moz-transform: translate3d(0, 0, 0);
+  -ms-transform: translate3d(0, 0, 0);
+  -o-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
+}
+
+/* line 48, ../src/sass/pikabu.scss */
+.m-pikabu-container {
+  width: 100%;
+  -webkit-backface-visibility: hidden;
+}
+/* line 53, ../src/sass/pikabu.scss */
+.m-pikabu-left-visible .m-pikabu-container.m-pikabu-left, .m-pikabu-right-visible .m-pikabu-container.m-pikabu-right {
+  position: absolute;
+}
+/* line 57, ../src/sass/pikabu.scss */
+.m-pikabu-left-visible .m-pikabu-container {
+  -webkit-transform: translate3d(80%, 0, 0);
+  -moz-transform: translate3d(80%, 0, 0);
+  -ms-transform: translate3d(80%, 0, 0);
+  -o-transform: translate3d(80%, 0, 0);
+  transform: translate3d(80%, 0, 0);
+}
+/* line 61, ../src/sass/pikabu.scss */
+.m-pikabu-right-visible .m-pikabu-container {
+  -webkit-transform: translate3d(-80%, 0, 0);
+  -moz-transform: translate3d(-80%, 0, 0);
+  -ms-transform: translate3d(-80%, 0, 0);
+  -o-transform: translate3d(-80%, 0, 0);
+  transform: translate3d(-80%, 0, 0);
+}
+
+/* line 67, ../src/sass/pikabu.scss */
+.m-pikabu-container,
+.m-pikabu-sidebar {
+  -webkit-transition: -webkit-transform 0.2s ease-in;
+  -moz-transition: -webkit-transform 0.2s ease-in;
+  -o-transition: -webkit-transform 0.2s ease-in;
+  transition: -webkit-transform 0.2s ease-in;
+}
+
+/* line 73, ../src/sass/pikabu.scss */
+.m-pikabu-overlay {
+  display: none;
+}
+/* line 77, ../src/sass/pikabu.scss */
+.m-pikabu-left-visible .m-pikabu-overlay, .m-pikabu-right-visible .m-pikabu-overlay {
+  position: absolute;
+  top: 0;
+  z-index: 30;
+  display: block;
+  height: 100%;
+  width: 100%;
+  cursor: pointer;
+}
+
+/* line 92, ../src/sass/pikabu.scss */
+.m-pikabu-overflow-scrolling .m-pikabu-sidebar {
+  overflow: auto;
+}
+
+/* line 96, ../src/sass/pikabu.scss */
+.m-pikabu-overflow-touch {
+  -webkit-overflow-scrolling: touch;
+}

--- a/pikabu/src/pikabu.js
+++ b/pikabu/src/pikabu.js
@@ -110,19 +110,22 @@ window.Pikabu = (function() {
     };
 
     pikabu.closeSidebars = function() {
+        window.scrollTo(0, 0);
         $document.removeClass('m-pikabu-left-visible m-pikabu-right-visible');
-        $('.m-pikabu-viewport, .m-pikabu-container').css('height', '');
-        $('.m-pikabu-container').css('marginTop', 1); // add this arbitrary margin-top to force a reflow when we remove it
         $('.m-pikabu-viewport').css('width', 'auto');
 
-        window.scrollTo(0, 1);
+        
       
-      // Removing overflow-scrolling-touch causes a content flash so we do it after the sidebar has closed
+        // 1. Removing overflow-scrolling-touch causes a content flash
+        // 2. Removing height too soom causes panel with few content to be not full height during animation
+        // so we do these after the sidebar has closed
         setTimeout(function() {
            $('.m-pikabu-sidebar').removeClass('m-pikabu-overflow-touch');
-        },250); 
-
-        $('.m-pikabu-container').css('marginTop', ''); // remove the unnecessary margin-top to force reflow and properly recalculate the height of this container
+           $('.m-pikabu-viewport, .m-pikabu-container').css('height', '');
+           $('.m-pikabu-container').css('marginTop', 1); // add this arbitrary margin-top to force a reflow when we remove it
+           window.scrollTo(0, 0); // 0, 0 fixes 1px glitch during animation and still does hide the address bar
+           $('.m-pikabu-container').css('marginTop', ''); // remove the unnecessary margin-top to force reflow and properly recalculate the height of this container
+        }, 250); 
     };
 
     pikabu.recalculateSidebarHeight = function(viewportHeight) {

--- a/pikabu/src/pikabu.js
+++ b/pikabu/src/pikabu.js
@@ -110,21 +110,18 @@ window.Pikabu = (function() {
     };
 
     pikabu.closeSidebars = function() {
-        window.scrollTo(0, 0);
         $document.removeClass('m-pikabu-left-visible m-pikabu-right-visible');
         $('.m-pikabu-viewport').css('width', 'auto');
-
-        
       
         // 1. Removing overflow-scrolling-touch causes a content flash
         // 2. Removing height too soom causes panel with few content to be not full height during animation
         // so we do these after the sidebar has closed
         setTimeout(function() {
-           $('.m-pikabu-sidebar').removeClass('m-pikabu-overflow-touch');
-           $('.m-pikabu-viewport, .m-pikabu-container').css('height', '');
-           $('.m-pikabu-container').css('marginTop', 1); // add this arbitrary margin-top to force a reflow when we remove it
-           window.scrollTo(0, 0); // 0, 0 fixes 1px glitch during animation and still does hide the address bar
-           $('.m-pikabu-container').css('marginTop', ''); // remove the unnecessary margin-top to force reflow and properly recalculate the height of this container
+            $('.m-pikabu-viewport, .m-pikabu-container').css('height', '');
+            $('.m-pikabu-container').css('marginTop', 1); // add this arbitrary margin-top to force a reflow when we remove it
+            window.scrollTo(0, 1);
+            $('.m-pikabu-container').css('marginTop', ''); // remove the unnecessary margin-top to force reflow and properly recalculate the height of this container
+            $('.m-pikabu-sidebar').removeClass('m-pikabu-overflow-touch');
         }, 250); 
     };
 

--- a/pikabu/src/sass/pikabu.scss
+++ b/pikabu/src/sass/pikabu.scss
@@ -12,7 +12,7 @@
     @include box-orient(horizontal);
     overflow: hidden;
   
-  -webkit-perspective: 1000;
+    -webkit-perspective: 1000;
     -webkit-transform: translateZ(0);
     -webkit-backface-visibility: hidden;
 }


### PR DESCRIPTION
When hiding a panel with few content (viewport is not tall enough to cover the entire screen), the height property is removed too soon that causes panel to appear not full-height while animating away.

Now remove viewport and container height when panel is closed (when animation is finished).

Also changed scrolling to 0,0 instead of 0,1 coordinates when panel is closed that fixes noticeable content 1px scroll and preserves hiding address bar (due to following ignored window.scroll to 0,1 on sidebar show [line 108]).
