### PR TITLE
Fix 1px scrolling issue on Pikabu animation

### DIFF
--- a/pikabu/src/pikabu.js
+++ b/pikabu/src/pikabu.js
@@ -105,7 +105,7 @@ window.Pikabu = (function() {
             $document.toggleClass('m-pikabu-' + type + '-visible');
 
             this.recalculateSidebarHeight($(window).height());
-            window.scrollTo(0, 1);
+            window.scrollTo(0, 0);
         }
     };
 

--- a/pikabu/src/pikabu.js
+++ b/pikabu/src/pikabu.js
@@ -110,18 +110,21 @@ window.Pikabu = (function() {
     };
 
     pikabu.closeSidebars = function() {
+        window.scrollTo(0, 0);
         $document.removeClass('m-pikabu-left-visible m-pikabu-right-visible');
         $('.m-pikabu-viewport').css('width', 'auto');
+
+        
       
         // 1. Removing overflow-scrolling-touch causes a content flash
         // 2. Removing height too soom causes panel with few content to be not full height during animation
         // so we do these after the sidebar has closed
         setTimeout(function() {
-            $('.m-pikabu-viewport, .m-pikabu-container').css('height', '');
-            $('.m-pikabu-container').css('marginTop', 1); // add this arbitrary margin-top to force a reflow when we remove it
-            window.scrollTo(0, 1);
-            $('.m-pikabu-container').css('marginTop', ''); // remove the unnecessary margin-top to force reflow and properly recalculate the height of this container
-            $('.m-pikabu-sidebar').removeClass('m-pikabu-overflow-touch');
+           $('.m-pikabu-sidebar').removeClass('m-pikabu-overflow-touch');
+           $('.m-pikabu-viewport, .m-pikabu-container').css('height', '');
+           $('.m-pikabu-container').css('marginTop', 1); // add this arbitrary margin-top to force a reflow when we remove it
+           window.scrollTo(0, 0); // 0, 0 fixes 1px glitch during animation and still does hide the address bar
+           $('.m-pikabu-container').css('marginTop', ''); // remove the unnecessary margin-top to force reflow and properly recalculate the height of this container
         }, 250); 
     };
 


### PR DESCRIPTION
window.scrollTo(0, 1) caused 1px scrolling issue due to top margin changes for reflowing.
Changing it to 0, 0 resolves scrolling issue.

Now double scroll fix like following is recommended on page load to hide the address bar and have page perfectly positioned:

window.scrollTo(0, 1);
window.scrollTo(0, 0);
