### PR TITLE
Relace usage of $.fn.detach with $.fn.remove

### DIFF
--- a/zoomable/src/zoomable.js
+++ b/zoomable/src/zoomable.js
@@ -141,7 +141,7 @@ Mobify.UI.Zoomable = (function() {
 
         this.$element.trigger('closing.zoomable');
 
-        this.$canvas.detach();
+        this.$canvas.remove();
         this.$stage.removeClass(this._getClass('zooming'));
 
         if (this.options.global) {


### PR DESCRIPTION
- Needed to support pre 1.0 versions of Zepto.
