### PR TITLE
Optional Event.preventDefault() calls and blank class prefix.

### DIFF
--- a/carousel/README.md
+++ b/carousel/README.md
@@ -68,6 +68,8 @@ Constructs the carousel with options.
           dragRadius: 10
         , moveRadius: 20
         , classPrefix: undefined
+	, preventDefault: true 		/* Whether to call Event.preventDefault() for all captured events.  
+					Set to false if you need carousel items to capture events (but you should still call preventDefault()). */
         , classNames: {
             outer: "carousel"
           , inner: "carousel-inner"

--- a/carousel/README.md
+++ b/carousel/README.md
@@ -68,8 +68,9 @@ Constructs the carousel with options.
           dragRadius: 10
         , moveRadius: 20
         , classPrefix: undefined
-	, preventDefault: true 		/* Whether to call Event.preventDefault() for all captured events.  
-					Set to false if you need carousel items to capture events (but you should still call preventDefault()). */
+        , preventDefault: true  /* Whether to call Event.preventDefault() for all captured events.  
+                                   Set to false if you need carousel items to capture events,
+                                   but you should still call preventDefault() to ensure normal carousel behaviour. */
         , classNames: {
             outer: "carousel"
           , inner: "carousel-inner"

--- a/carousel/src/carousel.js
+++ b/carousel/src/carousel.js
@@ -160,8 +160,9 @@ Mobify.UI.Carousel = (function($, Utils) {
         options.classNames = $.extend({}, options.classNames, opts.classNames || {});
 
         /* By default, classPrefix is `undefined`, which means to use the Mobify-wide level prefix */
-        options.classPrefix = options.classPrefix || Mobify.UI.classPrefix;
-
+        if ( typeof options.classPrefix === 'undefined' ) {
+            options.classPrefix = Mobify.UI.classPrefix;
+        }
         
         this.options = options;
     };

--- a/carousel/src/carousel.js
+++ b/carousel/src/carousel.js
@@ -128,6 +128,7 @@ Mobify.UI.Carousel = (function($, Utils) {
             dragRadius: 10
           , moveRadius: 20
           , classPrefix: undefined
+          , preventDefault: true
           , classNames: {
                 outer: 'carousel'
               , inner: 'carousel-inner'
@@ -269,7 +270,9 @@ Mobify.UI.Carousel = (function($, Utils) {
             , windowWidth = $(window).width();
 
         function start(e) {
-            if (!has.touch) e.preventDefault();
+            if (!has.touch && self.options.preventDefault) {
+                e.preventDefault();
+            }
 
             dragging = true;
             canceled = false;
@@ -296,8 +299,9 @@ Mobify.UI.Carousel = (function($, Utils) {
 
             if (dragThresholdMet || abs(dx) > abs(dy) && (abs(dx) > dragRadius)) {
                 dragThresholdMet = true;
-                e.preventDefault();
-                
+                if (self.options.preventDefault) {
+                    e.preventDefault();
+                }
                 if (lockLeft && (dx < 0)) {
                     dx = dx * (-dragLimit)/(dx - dragLimit);
                 } else if (lockRight && (dx > 0)) {
@@ -335,7 +339,9 @@ Mobify.UI.Carousel = (function($, Utils) {
         }
 
         function click(e) {
-            if (dragThresholdMet) e.preventDefault();
+            if (dragThresholdMet && self.options.preventDefault) {
+                e.preventDefault();
+            }
         }
 
         $inner
@@ -346,7 +352,9 @@ Mobify.UI.Carousel = (function($, Utils) {
             .on('mouseout.carousel', end);
 
         $element.on('click', '[data-slide]', function(e){
-            e.preventDefault();
+            if (self.options.preventDefault) {
+                e.preventDefault();
+            }
             var action = $(this).attr('data-slide')
               , index = parseInt(action, 10);
 


### PR DESCRIPTION
I needed to embed a Vimeo video as a carousel item and the Event.preventDefault() calls were preventing me from clicking the controls.

To fix this I made the Event.preventDefault() calls optional and instead called them myself in my application's code further down the DOM tree.
